### PR TITLE
ENH: proof-of-concept for opening a local port

### DIFF
--- a/AdsLib/AdsLib.cpp
+++ b/AdsLib/AdsLib.cpp
@@ -69,6 +69,11 @@ long AdsPortOpenEx()
     return GetRouter().OpenPort();
 }
 
+bool AdsPortOpenLocalEx(uint16_t& port)
+{
+    return GetRouter().OpenLocalPort(port);
+}
+
 long AdsGetLocalAddressEx(long port, AmsAddr* pAddr)
 {
     ASSERT_PORT_AND_AMSADDR(port, pAddr);

--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -57,6 +57,14 @@ long AdsPortCloseEx(long port);
 long AdsPortOpenEx();
 
 /**
+ * Establishes a connection (communication port) to the message
+ * router on localhost. The port number returned by AdsPortOpenEx() is required as
+ * parameter for further AdsLib function calls.
+ * @return port number of a new Ads port or 0 if no more ports available
+ */
+bool AdsPortOpenLocalEx(uint16_t& port);
+
+/**
  * Returns the local NetId and port number.
  * @param[in] port port number of an Ads port that had previously been opened with AdsPortOpenEx().
  * @param[out] pAddr Pointer to the structure of type AmsAddr.

--- a/AdsLib/AmsConnection.cpp
+++ b/AdsLib/AmsConnection.cpp
@@ -20,6 +20,8 @@
    SOFTWARE.
  */
 
+#include <thread>
+
 #include "AmsConnection.h"
 #include "Log.h"
 
@@ -308,6 +310,10 @@ void AmsConnection::Recv()
 {
     AmsTcpHeader amsTcpHeader;
     AoEHeader aoeHeader;
+    // TODO: this is not how this should be synchronized, clearly!
+    // this just gives the "local port request" method time to run
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    LOG_WARN("Recv() delayed start");
     for ( ; ownIp; ) {
         Receive(amsTcpHeader);
         if (amsTcpHeader.length() < sizeof(aoeHeader)) {

--- a/AdsLib/AmsConnection.cpp
+++ b/AdsLib/AmsConnection.cpp
@@ -167,7 +167,7 @@ uint32_t AmsConnection::GetInvokeId()
 
 AmsResponse* AmsConnection::GetPending(const uint32_t id, const uint16_t port)
 {
-    const uint16_t portIndex = port - Router::PORT_BASE;
+    const uint16_t portIndex = port;
     if (portIndex >= Router::NUM_PORTS_MAX) {
         LOG_WARN("Port 0x" << std::hex << port << " is out of range");
         return nullptr;
@@ -184,11 +184,11 @@ AmsResponse* AmsConnection::GetPending(const uint32_t id, const uint16_t port)
 AmsResponse* AmsConnection::Reserve(AmsRequest* request, const uint16_t port)
 {
     AmsRequest* isFree = nullptr;
-    if (!queue[port - Router::PORT_BASE].request.compare_exchange_strong(isFree, request)) {
+    if (!queue[port].request.compare_exchange_strong(isFree, request)) {
         LOG_WARN("Port: " << port << " already in use as " << isFree);
         return nullptr;
     }
-    return &queue[port - Router::PORT_BASE];
+    return &queue[port];
 }
 
 void AmsResponse::Release()

--- a/AdsLib/AmsConnection.h
+++ b/AdsLib/AmsConnection.h
@@ -110,6 +110,8 @@ private:
     void Recv();
     void TryRecv();
     uint32_t GetInvokeId();
+    bool RequestLocalPort(uint16_t &port);
+    bool FreeLocalPort(uint16_t port);
     AmsResponse* Reserve(AmsRequest* request, uint16_t port);
     AmsResponse* GetPending(uint32_t id, uint16_t port);
 

--- a/AdsLib/AmsPort.cpp
+++ b/AdsLib/AmsPort.cpp
@@ -32,7 +32,8 @@ bool operator==(const AmsAddr& lhs, const AmsAddr& rhs)
 
 AmsPort::AmsPort()
     : tmms(DEFAULT_TIMEOUT),
-    port(0)
+    port(0),
+    local(false)
 {}
 
 void AmsPort::AddNotification(NotifyMapping mapping)
@@ -74,8 +75,9 @@ bool AmsPort::IsOpen() const
     return !!port;
 }
 
-uint16_t AmsPort::Open(uint16_t __port)
+uint16_t AmsPort::Open(uint16_t __port, bool __local)
 {
     port = __port;
+    local = __local;
     return port;
 }

--- a/AdsLib/AmsPort.h
+++ b/AdsLib/AmsPort.h
@@ -33,9 +33,10 @@ struct AmsPort {
     AmsPort();
     void Close();
     bool IsOpen() const;
-    uint16_t Open(uint16_t __port);
+    uint16_t Open(uint16_t __port, bool __local = false);
     uint32_t tmms;
     uint16_t port;
+    bool local;
 
     void AddNotification(NotifyMapping mapping);
     long DelNotification(const AmsAddr& ams, uint32_t hNotify);

--- a/AdsLib/AmsRouter.h
+++ b/AdsLib/AmsRouter.h
@@ -29,6 +29,7 @@ struct AmsRouter : Router {
     AmsRouter(AmsNetId netId = AmsNetId {});
 
     uint16_t OpenPort();
+    bool OpenLocalPort(uint16_t &port);
     long ClosePort(uint16_t port);
     long GetLocalAddress(uint16_t port, AmsAddr* pAddr);
     void SetLocalAddress(AmsNetId netId);

--- a/AdsLib/Router.h
+++ b/AdsLib/Router.h
@@ -26,9 +26,8 @@
 #include "AdsDef.h"
 
 struct Router {
-    static const size_t NUM_PORTS_MAX = 128;
-    static const uint16_t PORT_BASE = 30000;
-    static_assert(NUM_PORTS_MAX + PORT_BASE <= UINT16_MAX, "Port limit is out of range");
+    static const size_t NUM_PORTS_MAX = 65535;
+    static_assert(NUM_PORTS_MAX <= UINT16_MAX, "Port limit is out of range");
 
     virtual long GetLocalAddress(uint16_t port, AmsAddr* pAddr) = 0;
 };


### PR DESCRIPTION
### Purpose

This is a proof-of-concept for allowing ADS clients to talk to localhost by way of requesting a unique AMS/ADS port from the ADS router itself.

### Preliminary success

Paired with https://github.com/pcdshub/twincat-ads/pull/12 and [ads-ioc](https://github.com/pcdshub/ads-ioc/), these changes allowed for an unmodified rhel7-x86_64 (_Linux_) ads-ioc binary, running on TwinCAT BSD with the LinuxEmu layer enabled, to successfully communicate with localhost and serve PVs. 🎆 

Sample PLC project and IOC used to verify this:
* PLC project: https://github.com/pcdshub/pytmc-simple-project
* IOC startup script: https://github.com/pcdshub/pytmc-simple-project/blob/master/iocBoot/ioc-pytmc-simple-plc/st.cmd
* Database: https://github.com/pcdshub/pytmc-simple-project/blob/master/iocBoot/ioc-pytmc-simple-plc/pytmc_simple_plc.db

### Note

Note that we (at PCDS) are way behind the upstream [Beckhoff/ADS](https://github.com/Beckhoff/ADS/). As the upstream has significantly diverged from our fork, this effort would need to be redone entirely were we to ever sync/upgrade.

### Changes

A few changes were necessary:
* The ADS library counted ports from presumably a "free" area (30,000-65535). This was redone to track all ports from 0-65535, which certainly consumes a bit more memory yet also makes the array indexing logic markedly easier.
* A new exported function `AdsPortOpenLocalEx` was added to perform this request. It needs to be called prior to any other ADS calls when the client recognizes that it is talking to localhost.
   * This is assuredly not the best place for it design-wise - the functionality as far as I can see doesn't really fit into the ADS library at all (but I would be happy to be proven wrong here; so feel free to comment).


#### Prior to this PR

Prior to this PR, the ADS library picks a port on its own and continues with it.

* When opening a port in the "router" built into the free ADS library (by way of `AdsPortOpenEx()` ) merely reserves an integer AMS port ID locally and uses that for future communication ("request port ID, use that port ID to talk to AMS Net ID 8.8.8.8.1.1 port PLC_TC3 and read data from it"). 
* This is reflected in this code: https://github.com/pcdshub/ADS/blob/743a15afbb4b63ebb1670595ca382a783d72bfb1/AdsLib/AmsRouter.cpp#L86-L96
* It's effectively a free-for-all of port selection - "this application is free to reserve whatever ADS port it wants because there's no PLC running, no ADS router running, etc."
* That local port is used in the AMS-over-Ethernet header as the source and the target PLC responds back to that port in requests.

### Beyond a prototype

A few things to move this out of the prototype stage would include:
* Remove the `Recv()` startup delay and replace it with some better thread-safe mechanism to only wait when necessary (or perhaps build the "wait for local port packet" into the `AmsConnection` class somehow)
* Removing/lowering the warning level of all the debug prints
* Remove the `local` `AmsPort` bool because I didn't end up using it
* Adding the ability to free/deallocate the port from the PLC (see my comment links for reference here https://github.com/Beckhoff/ADS/issues/190#issuecomment-1761052956)
* Were this used to talk to multiple PLCs (localhost and one or more non-local hosts), the localhost connection would have to come first. This may need a workaround.
   * Expanding on that - if "localhost port open first" order is not followed, this scenario is possible:
       * To communicate with a non-localhost PLC, an arbitrary AMS port is chosen by the ADS lib by way of `AdsPortOpenEx()`: port X
       * `AdsPortOpenLocalEx()` is called to communicate with localhost, and this port number is identical to that from the previous step (somewhere around a probability of 1/65535....)
       * This port is already in use in the router and problems could potentially arise